### PR TITLE
apply an hack

### DIFF
--- a/.github/workflows/api.yml
+++ b/.github/workflows/api.yml
@@ -60,7 +60,8 @@ jobs:
       - name: Run static analysis
         run: |
           cat ops/kubernetes/backend/api/jobs/analyse.yaml | sed -e "s/{{VERSION}}/${{ env.DEPLOYMENT_VERSION }}/g" -e "s/{{REPOSITORY}}/${{ env.DOCKER_IMAGE }}-test/g" | kubectl apply -f -
-          kubectl logs job/api-code-analysis --follow --pod-running-timeout=65s
+          kubectl logs --follow job/api-code-analysis &
+          kubectl wait --for=condition=complete --timeout=86400s job/api-code-analysis
   test:
     runs-on: self-hosted
     needs: analyse
@@ -74,7 +75,8 @@ jobs:
       - name: Run integration tests
         run: |
           cat ops/kubernetes/backend/api/jobs/run_tests.yaml | sed -e "s/{{VERSION}}/${{ env.DEPLOYMENT_VERSION }}/g" -e "s/{{REPOSITORY}}/${{ env.DOCKER_IMAGE }}-test/g" | kubectl apply -f -
-          kubectl logs job/api-integration-tests --follow --pod-running-timeout=65s
+          kubectl logs --follow job/api-integration-tests &
+          kubectl wait --for=condition=complete --timeout=86400s job/api-integration-tests
   migrations:
     runs-on: self-hosted
     needs: test


### PR DESCRIPTION
it seems like --follow fails because container is not yet created, e.g container has no logs. so what I'll do is just listen for the logs in the background and wait for the job to complete on the foreground.
there is still an open issue on kubernetes community on github sense 2016 https://github.com/kubernetes/kubernetes/issues/28746